### PR TITLE
Allow re run

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Role is self sustainable - it installs all needed prerequisites on the target no
 
 ## Role Variables
 
-Available variables are listed below along with their default values:
+Available variables are listed below along with their default values. Please generate an app key with `php artisan key:generate --show` and replace `snipe_app_key`.
 
 ```yaml
 #if you want to purge all php, nginx, apache2 installation and configuration change it to true
@@ -21,6 +21,7 @@ snipe_domain: localhost
 snipe_environment: production
 snipe_debug_mode: false
 snipe_http_server: nginx
+snipe_app_key: ChangeMe
 
 #default db settings
 snipe_db_host: localhost

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ snipe_environment: production
 snipe_debug_mode: false
 snipe_log_debug_mode: warning
 snipe_http_server: nginx
+snipe_app_key: ChangeMe
 snipe_db_host: localhost
 snipe_db_port: 3306
 snipe_db_name: snipeit

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 # defaults file for snipe-it
 snipe_clean_env: false
 snipe_install_dir: /opt/snipe-it
-snipe_install_version: 6.0.2
+snipe_install_version: 6.0.14
 snipe_environment: production
 snipe_debug_mode: false
 snipe_log_debug_mode: warning

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 # defaults file for snipe-it
 snipe_clean_env: false
 snipe_install_dir: /opt/snipe-it
-snipe_install_version: 6.0.14
+snipe_install_version: 6.0.2
 snipe_environment: production
 snipe_debug_mode: false
 snipe_log_debug_mode: warning

--- a/tasks/host_bootstrap.yml
+++ b/tasks/host_bootstrap.yml
@@ -1,6 +1,6 @@
 - name: Host Bootstrap | Install prerequisites
   apt:
-    name: [software-properties-common, git, debconf-utils, unzip]
+    name: [software-properties-common, git, debconf-utils, unzip, curl]
     state: present
   become: true
 
@@ -49,7 +49,8 @@
   apt:
     name: [default-mysql-server, python3-mysqldb]
     state: present
-  become: true  
+  become: true
+  register: mysqlinstall
 
 - name: Set MySQL root Password
   become: True
@@ -60,6 +61,7 @@
     login_user: "root"
     login_password: ""
     state: present
+  when: mysqlinstall.changed
 
 - name: Host Bootstrap | Mysql | Create database
   mysql_db:

--- a/tasks/snipeit_install.yml
+++ b/tasks/snipeit_install.yml
@@ -48,13 +48,8 @@
     chdir: "{{ snipe_install_dir }}"
     creates: "{{ snipe_install_dir }}/vendor"
     warn: no
-  become: true
-
-- name: Snipe install | Generate app_key
-  command: php artisan key:generate --force
-  args:
-    chdir: "{{ snipe_install_dir }}"
-    warn: no
+  environment:
+    COMPOSER_ALLOW_SUPERUSER: 1
   become: true
 
 - name: Snipe install | Clear cached config

--- a/templates/dotenv.j2
+++ b/templates/dotenv.j2
@@ -3,7 +3,7 @@
 # --------------------------------------------
 APP_ENV={{snipe_environment}}
 APP_DEBUG={{snipe_debug_mode}}
-APP_KEY=ChangeMe
+APP_KEY={{snipe_app_key}}
 APP_URL=http://{{snipe_domain}}
 APP_TIMEZONE='UTC'
 APP_LOCALE=en


### PR DESCRIPTION
- Install curl
- Allow php composer installation without interaction by setting COMPOSER_ALLOW_SUPERUSER env var
- Remove APP_KEY generation from role as it overwrites the current one every time. You now have to generate it manually and set it in your host vars.
- Change mysql password only during initial mysql installation