### PR TITLE
Remove deprecated warn. parameter

### DIFF
--- a/tasks/snipeit_install.yml
+++ b/tasks/snipeit_install.yml
@@ -37,7 +37,6 @@
   shell: curl -sS https://getcomposer.org/installer | php
   args:
     chdir: "{{ snipe_install_dir }}"
-    warn: no
     executable: /bin/bash
     creates: "{{ snipe_install_dir }}/composer.phar"
   become: true
@@ -47,7 +46,6 @@
   args:
     chdir: "{{ snipe_install_dir }}"
     creates: "{{ snipe_install_dir }}/vendor"
-    warn: no
   environment:
     COMPOSER_ALLOW_SUPERUSER: 1
   become: true
@@ -56,7 +54,6 @@
   command: php artisan config:clear
   args:
     chdir: "{{ snipe_install_dir }}"
-    warn: no
   become: true
 
 - name: Snipe install | Copy updated nginx site config


### PR DESCRIPTION
The `warn` parameter for `shell` was deprecated in `Ansible` `2.11` and removed in `Ansible` `2.14`.

We have to remove all the `warn` entries on all `shell` tasks in the role.