### PR TITLE
fix: Adjust directory copy behavior based on trailing slash

### DIFF
--- a/tasks/snipeit_install.yml
+++ b/tasks/snipeit_install.yml
@@ -11,7 +11,7 @@
 
 - name: "Copy {{ snipe_install_dir }}-{{ snipe_install_version }} in to {{ snipe_install_dir }}"
   copy:
-    src: "{{ snipe_install_dir }}-{{ snipe_install_version }}"
+    src: "{{ snipe_install_dir }}-{{ snipe_install_version }}/"
     dest: "{{ snipe_install_dir }}"
     mode: 0775
     owner: www-data


### PR DESCRIPTION
If path is a directory, it is copied recursively. In this case, if path ends with `/`, only inside contents of that directory are copied to destination. Otherwise, if it does not end with `/`, the directory itself with all contents is copied. This behavior is similar to the rsync command line tool.